### PR TITLE
Change zero to nan for lack of data

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+* Change 0.0 to nan if there is no data available

--- a/src/frequenz/reporting/_reporting.py
+++ b/src/frequenz/reporting/_reporting.py
@@ -114,7 +114,7 @@ async def cumulative_energy(
                 elif last_value_diff < 0:
                     production += last_value_diff
     else:
-        consumption = production = 0.0
+        consumption = production = float("nan")
 
     return CumulativeEnergy(
         start_time=start_time,


### PR DESCRIPTION
As identified by Noah if there is no data we should get `nan` instead of `0.0`