### PR TITLE
Support secret to sign requests to reporting client

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- The reporting API client version is updated to `>= 0.18.0, < 0.19.0`.
 
 ## New Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 dependencies = [
   "typing-extensions >= 4.6.1, < 5",
-  "frequenz-client-reporting>=0.13.0, < 1",
+  "frequenz-client-reporting >= 0.18.0, < 0.19.0",
   "frequenz-client-common >= 0.3.0, < 0.4",
 ]
 dynamic = ["version"]

--- a/src/frequenz/reporting/_reporting.py
+++ b/src/frequenz/reporting/_reporting.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from frequenz.client.common.metric import Metric
 from frequenz.client.reporting import ReportingApiClient
-from frequenz.client.reporting._client import MetricSample
+from frequenz.client.reporting._types import MetricSample
 
 CumulativeEnergy = namedtuple(
     "CumulativeEnergy", ["start_time", "end_time", "consumption", "production"]
@@ -49,11 +49,11 @@ async def cumulative_energy(
 
     metric_samples = [
         sample
-        async for sample in client.list_microgrid_components_data(
+        async for sample in client.receive_microgrid_components_data(
             microgrid_components=[(microgrid_id, [component_id])],
             metrics=metric,
-            start_dt=start_time,
-            end_dt=end_time,
+            start_time=start_time,
+            end_time=end_time,
             resampling_period=resampling_period,
         )
     ]
@@ -101,22 +101,22 @@ async def cumulative_energy(
             # Fetch energy consumption and production metrics separately
             consumption_samples = [
                 sample
-                async for sample in client.list_microgrid_components_data(
+                async for sample in client.receive_microgrid_components_data(
                     microgrid_components=[(microgrid_id, [component_id])],
                     metrics=Metric.AC_ACTIVE_ENERGY_CONSUMED,
-                    start_dt=start_time,
-                    end_dt=end_time,
+                    start_time=start_time,
+                    end_time=end_time,
                     resampling_period=resampling_period,
                 )
             ]
 
             production_samples = [
                 sample
-                async for sample in client.list_microgrid_components_data(
+                async for sample in client.receive_microgrid_components_data(
                     microgrid_components=[(microgrid_id, [component_id])],
                     metrics=Metric.AC_ACTIVE_ENERGY_DELIVERED,
-                    start_dt=start_time,
-                    end_dt=end_time,
+                    start_time=start_time,
+                    end_time=end_time,
                     resampling_period=resampling_period,
                 )
             ]
@@ -350,11 +350,11 @@ async def _fetch_component_data(
     """
     return [
         sample
-        async for sample in client.list_microgrid_components_data(
+        async for sample in client.receive_microgrid_components_data(
             microgrid_components=microgrid_components,
             metrics=metrics,
-            start_dt=start_time,
-            end_dt=end_time,
+            start_time=start_time,
+            end_time=end_time,
             resampling_period=resampling_period,
             include_states=include_states,
             include_bounds=include_bounds,

--- a/tests/test_frequenz_reporting.py
+++ b/tests/test_frequenz_reporting.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Any
 
 import pytest
-from frequenz.client.reporting._client import MetricSample
+from frequenz.client.reporting._types import MetricSample
 
 from frequenz.reporting import delete_me
 from frequenz.reporting._reporting import extract_state_durations
@@ -23,8 +23,8 @@ test_cases_extract_state_durations = [
     {
         "description": "No matching metrics",
         "samples": [
-            MetricSample(datetime(2023, 1, 1, 0, 0), 1, 101, "temperature", 25),
-            MetricSample(datetime(2023, 1, 1, 1, 0), 1, 101, "humidity", 60),
+            MetricSample(datetime(2023, 1, 1, 0, 0), 1, "101", "temperature", 25),
+            MetricSample(datetime(2023, 1, 1, 1, 0), 1, "101", "humidity", 60),
         ],
         "alert_states": [1],
         "include_warnings": True,
@@ -34,15 +34,15 @@ test_cases_extract_state_durations = [
     {
         "description": "Single state change",
         "samples": [
-            MetricSample(datetime(2023, 1, 1, 0, 0), 1, 101, "state", 0),
-            MetricSample(datetime(2023, 1, 1, 1, 0), 1, 101, "state", 1),
+            MetricSample(datetime(2023, 1, 1, 0, 0), 1, "101", "state", 0),
+            MetricSample(datetime(2023, 1, 1, 1, 0), 1, "101", "state", 1),
         ],
         "alert_states": [1],
         "include_warnings": True,
         "expected_all_states": [
             {
                 "microgrid_id": 1,
-                "component_id": 101,
+                "component_id": "101",
                 "state_type": "state",
                 "state_value": 0,
                 "start_time": datetime(2023, 1, 1, 0, 0),
@@ -50,7 +50,7 @@ test_cases_extract_state_durations = [
             },
             {
                 "microgrid_id": 1,
-                "component_id": 101,
+                "component_id": "101",
                 "state_type": "state",
                 "state_value": 1,
                 "start_time": datetime(2023, 1, 1, 1, 0),
@@ -60,7 +60,7 @@ test_cases_extract_state_durations = [
         "expected_alert_records": [
             {
                 "microgrid_id": 1,
-                "component_id": 101,
+                "component_id": "101",
                 "state_type": "state",
                 "state_value": 1,
                 "start_time": datetime(2023, 1, 1, 1, 0),
@@ -71,10 +71,10 @@ test_cases_extract_state_durations = [
     {
         "description": "Warnings and errors included",
         "samples": [
-            MetricSample(datetime(2023, 1, 2, 0, 0), 3, 303, "state", 0),
-            MetricSample(datetime(2023, 1, 2, 0, 30), 3, 303, "warning", "W1"),
-            MetricSample(datetime(2023, 1, 2, 1, 0), 3, 303, "state", 1),
-            MetricSample(datetime(2023, 1, 2, 1, 30), 3, 303, "error", "E1"),
+            MetricSample(datetime(2023, 1, 2, 0, 0), 3, "303", "state", 0),
+            MetricSample(datetime(2023, 1, 2, 0, 30), 3, "303", "warning", 10),
+            MetricSample(datetime(2023, 1, 2, 1, 0), 3, "303", "state", 1),
+            MetricSample(datetime(2023, 1, 2, 1, 30), 3, "303", "error", 20),
         ],
         "alert_states": [1],
         "include_warnings": True,
@@ -82,7 +82,7 @@ test_cases_extract_state_durations = [
             # State transitions
             {
                 "microgrid_id": 3,
-                "component_id": 303,
+                "component_id": "303",
                 "state_type": "state",
                 "state_value": 0,
                 "start_time": datetime(2023, 1, 2, 0, 0),
@@ -90,7 +90,7 @@ test_cases_extract_state_durations = [
             },
             {
                 "microgrid_id": 3,
-                "component_id": 303,
+                "component_id": "303",
                 "state_type": "state",
                 "state_value": 1,
                 "start_time": datetime(2023, 1, 2, 1, 0),
@@ -99,18 +99,18 @@ test_cases_extract_state_durations = [
             # Warning transitions
             {
                 "microgrid_id": 3,
-                "component_id": 303,
+                "component_id": "303",
                 "state_type": "warning",
-                "state_value": "W1",
+                "state_value": 10,
                 "start_time": datetime(2023, 1, 2, 0, 30),
                 "end_time": None,
             },
             # Error transitions
             {
                 "microgrid_id": 3,
-                "component_id": 303,
+                "component_id": "303",
                 "state_type": "error",
-                "state_value": "E1",
+                "state_value": 20,
                 "start_time": datetime(2023, 1, 2, 1, 30),
                 "end_time": None,
             },
@@ -118,24 +118,24 @@ test_cases_extract_state_durations = [
         "expected_alert_records": [
             {
                 "microgrid_id": 3,
-                "component_id": 303,
+                "component_id": "303",
                 "state_type": "warning",
-                "state_value": "W1",
+                "state_value": 10,
                 "start_time": datetime(2023, 1, 2, 0, 30),
                 "end_time": None,
             },
             {
                 "microgrid_id": 3,
-                "component_id": 303,
+                "component_id": "303",
                 "state_type": "error",
-                "state_value": "E1",
+                "state_value": 20,
                 "start_time": datetime(2023, 1, 2, 1, 30),
                 "end_time": None,
             },
             # State alert
             {
                 "microgrid_id": 3,
-                "component_id": 303,
+                "component_id": "303",
                 "state_type": "state",
                 "state_value": 1,
                 "start_time": datetime(2023, 1, 2, 1, 0),


### PR DESCRIPTION
- Includes various naming updates that come with the new reporting client version.
- Replaced deprecated `MetricSample` imports.
- Updated tests to use string-based component IDs and numeric state values due to `MetricSample` now being stronly typed.